### PR TITLE
Include jedi.inc as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Code/DDevExtensions/jedi"]
+	path = Code/DDevExtensions/jedi
+	url = https://github.com/project-jedi/jedi.git

--- a/Code/DDevExtensions/Source/DelphiExtension.inc
+++ b/Code/DDevExtensions/Source/DelphiExtension.inc
@@ -14,7 +14,7 @@
   {$IFEND}
 {$ENDIF}
 
-{$I jedi\jedi.inc}
+{$I ..\jedi\jedi.inc}
 
 {$DEFINE DDEVEXTENSIONS}
 

--- a/CompileInterceptor/Source/CompileInterceptor.inc
+++ b/CompileInterceptor/Source/CompileInterceptor.inc
@@ -1,2 +1,2 @@
-{$I jedi\jedi.inc}
+{$I ..\jedi\jedi.inc}
 

--- a/Shared/FileStreams.pas
+++ b/Shared/FileStreams.pas
@@ -9,7 +9,7 @@
 
 unit FileStreams;
 
-{$I jedi\jedi.inc}
+{$I ..\jedi\jedi.inc}
 
 interface
 

--- a/Shared/IDE/Options/FrmTreePages.pas
+++ b/Shared/IDE/Options/FrmTreePages.pas
@@ -7,7 +7,7 @@
 
 unit FrmTreePages;
 
-{$I jedi\jedi.inc}
+{$I ..\jedi\jedi.inc}
 
 interface
 

--- a/Shared/IDE/ProjectData.pas
+++ b/Shared/IDE/ProjectData.pas
@@ -8,7 +8,7 @@
 
 unit ProjectData;
 
-{$I jedi\jedi.inc}
+{$I ..\jedi\jedi.inc}
 
 interface
 

--- a/Shared/IDE/ProjectResource.pas
+++ b/Shared/IDE/ProjectResource.pas
@@ -8,7 +8,7 @@
 
 unit ProjectResource;
 
-{$I jedi\jedi.inc}
+{$I ..\jedi\jedi.inc}
 
 interface
 

--- a/Shared/PascalParser/DelphiParser.inc
+++ b/Shared/PascalParser/DelphiParser.inc
@@ -1,1 +1,1 @@
-{$I jedi\jedi.inc}
+{$I ..\jedi\jedi.inc}

--- a/Shared/PascalParser/DelphiParserContainers.pas
+++ b/Shared/PascalParser/DelphiParserContainers.pas
@@ -8,7 +8,7 @@
 
 unit DelphiParserContainers;
 
-{$I jedi\jedi.inc}
+{$I ..\jedi\jedi.inc}
 
 {$IFDEF COMPILER10_UP}
  {$DEFINE D9}

--- a/Shared/Xml/SimpleXmlDoc.pas
+++ b/Shared/Xml/SimpleXmlDoc.pas
@@ -6,7 +6,7 @@
 
 unit SimpleXmlDoc;
 
-{$I jedi\jedi.inc}
+{$I ..\jedi\jedi.inc}
 
 interface
 


### PR DESCRIPTION
Instead of manually downloading the ``jedi.inc`` file from the jedi repository include the file as a submodule.