### PR TITLE
Bump minor version to 88 in version.bat

### DIFF
--- a/Code/DDevExtensions/version.bat
+++ b/Code/DDevExtensions/version.bat
@@ -1,2 +1,2 @@
 @SET majorversion=2
-@SET minorversion=87
+@SET minorversion=88


### PR DESCRIPTION
When version 2.88 was released the minor version number was left behind, resulting in DLLs that had the same `ProductVersion` and `FileVersion` as the previous release.