### PR TITLE
Add implicit project search path to file selector paths

### DIFF
--- a/Code/DDevExtensions/Source/FileSelector/FrmFileSelector.pas
+++ b/Code/DDevExtensions/Source/FileSelector/FrmFileSelector.pas
@@ -1254,6 +1254,7 @@ begin
     if Project <> nil then
     begin
       FProjectFilename := Project.FileName;
+      Dirs := Dirs + ';' + ExtractFilePath(FProjectFilename);
       Dirs := Dirs + ';' + VarToStrDef(Project.ProjectOptions.Values['UnitDir'], '');
     end;
 


### PR DESCRIPTION
Files that are adjacent to the project file are implicitly on the search path. Unless they were explicitly included in the `.dpr`, these files are not present in the file selector.